### PR TITLE
feat: Change ClusterIssuer solver

### DIFF
--- a/charts/acme-nonereqs/templates/cert-manager-prod-clusterissuer.yaml
+++ b/charts/acme-nonereqs/templates/cert-manager-prod-clusterissuer.yaml
@@ -21,8 +21,7 @@ spec:
       name: letsencrypt-{{ $val.domain | replace "." "-" }}-prod-extra
     solvers:
     - selector:
-        dnsNames:
-        - "*.{{ $val.domain }}"
+        dnsZones:
         - "{{ $val.domain }}"
         # ACME DNS-01 provider configurations
       dns01:

--- a/charts/acme-nonereqs/templates/cert-manager-staging-clusterissuer.yaml
+++ b/charts/acme-nonereqs/templates/cert-manager-staging-clusterissuer.yaml
@@ -21,8 +21,7 @@ spec:
       name: letsencrypt-{{ $val.domain | replace "." "-" }}-staging-extra
     solvers:
     - selector:
-        dnsNames:
-        - "*.{{ $val.domain }}"
+        dnsZones:
         - "{{ $val.domain }}"
         # ACME DNS-01 provider configurations
       dns01:

--- a/charts/acme/templates/cert-manager-prod-clusterissuer.yaml
+++ b/charts/acme/templates/cert-manager-prod-clusterissuer.yaml
@@ -14,13 +14,11 @@ spec:
       name: letsencrypt-prod
     solvers:
     - selector:
-        dnsNames:
-        - "*.{{ .Values.jxRequirements.ingress.domain }}"
+        dnsZones:
         - "{{ .Values.jxRequirements.ingress.domain }}"
         {{- if hasKey .Values.jxRequirements "extraDomains" }}
         {{- range $key, $val := .Values.jxRequirements.extraDomains }}
         {{- if $val.tls.enabled}}
-        - "*.{{ $val.domain }}"
         - "{{ $val.domain }}"
         {{- end }}
         {{- end }}

--- a/charts/acme/templates/cert-manager-staging-clusterissuer.yaml
+++ b/charts/acme/templates/cert-manager-staging-clusterissuer.yaml
@@ -15,13 +15,11 @@ spec:
       name: letsencrypt-staging
     solvers:
     - selector:
-        dnsNames:
-        - "*.{{ .Values.jxRequirements.ingress.domain }}"
+        dnsZones:
         - "{{ .Values.jxRequirements.ingress.domain }}"
         {{- if hasKey .Values.jxRequirements "extraDomains" }}
         {{- range $key, $val := .Values.jxRequirements.extraDomains }}
         {{- if $val.tls.enabled}}
-        - "*.{{ $val.domain }}"
         - "{{ $val.domain }}"
         {{- end }}
         {{- end }}


### PR DESCRIPTION
Thsi is for Payments and the ability to have Issuer Certificates (which is why for payments with Barclays we can't use mqube-certificate-service) as they have to be froma trusted sourece , we want to use LetsEncrypt and have cert-manager but it works with the dnsName not dnsZones , and we don't want to share certificates (as we did when tetsign JWKS as you'll have the issue we had the other week) 